### PR TITLE
Implement variable scores to spawned crates

### DIFF
--- a/Project/Assets/_Data/Prefabs/Environment/Crates/CrateSpawner.prefab
+++ b/Project/Assets/_Data/Prefabs/Environment/Crates/CrateSpawner.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3838056687444560140}
   - component: {fileID: 4649749589772436556}
+  - component: {fileID: 4322882342134811817}
   m_Layer: 0
   m_Name: CrateSpawner
   m_TagString: Untagged
@@ -45,7 +46,24 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cratePrefab: {fileID: 3767048393502162153, guid: 25706bb730b17b54e80fe11a22508e4b, type: 3}
-  spawnInterval: 10
-  spawnGroups: []
+  timer: {fileID: 4322882342134811817}
   spawnRequirements: []
-  collector: {fileID: 0}
+--- !u!114 &4322882342134811817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5813500355358272119}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f92cff4f332bf54a88d1ac7e88b15b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  duration: 2
+  repeat: 1
+  autoStart: 0
+  timeout:
+    m_PersistentCalls:
+      m_Calls: []
+  paused: 0

--- a/Project/Assets/_Data/Scenes/AlphaLevel.unity
+++ b/Project/Assets/_Data/Scenes/AlphaLevel.unity
@@ -24462,6 +24462,62 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 244573964}
     m_Modifications:
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerEnded.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerStarted.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerEnded.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerEnded.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2105146819}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerStarted.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerStarted.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2105146819}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerEnded.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerEnded.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: StopSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerStarted.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerStarted.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: StartSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerEnded.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: CrateSpawner, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerStarted.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: CrateSpawner, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerEnded.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
+      propertyPath: SchedulerStarted.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 3783382105403885408, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
       propertyPath: m_Name
       value: CrateCollector
@@ -24624,7 +24680,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4703953586703455807, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
       propertyPath: onRequirementUpdate.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: RequirementsText, Assembly-CSharp
+      value: QuotaDisplayText, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 4703953586703455807, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
       propertyPath: onEvaluatedRequirement.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
@@ -24632,15 +24688,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4703953586703455807, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
       propertyPath: onCollectionPeriodEnded.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: RequirementsText, Assembly-CSharp
+      value: QuotaDisplayText, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 4703953586703455807, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
       propertyPath: onCollectionPeriodStarted.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: RequirementsText, Assembly-CSharp
+      value: QuotaDisplayText, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 4703953586703455807, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
       propertyPath: onItemsForCollectionChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: RequirementsText, Assembly-CSharp
+      value: QuotaDisplayText, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 4703953586703455807, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}
       propertyPath: onCollection.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -42168,10 +42224,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4322882342134811817, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: collector
       value: 
       objectReference: {fileID: 1149637560}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnExtra
       value: 21
@@ -43335,6 +43399,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3838056687444560140, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
   m_PrefabInstance: {fileID: 2105146817}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2105146819 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+  m_PrefabInstance: {fileID: 2105146817}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7849968029e9394d9b790a749fda260, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2112913430
 GameObject:
   m_ObjectHideFlags: 0

--- a/Project/Assets/_Data/Scenes/AlphaLevel.unity
+++ b/Project/Assets/_Data/Scenes/AlphaLevel.unity
@@ -43217,6 +43217,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 830668616}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[0].tag
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[1].tag
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[2].tag
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnGroups.Array.data[0].parentTransform
       value: 
       objectReference: {fileID: 1127615680}
@@ -43228,6 +43240,30 @@ PrefabInstance:
       propertyPath: spawnGroups.Array.data[2].parentTransform
       value: 
       objectReference: {fileID: 830668616}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[0].crateScore
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[0].spawnCount
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[1].crateScore
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[1].spawnCount
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[2].crateScore
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[2].spawnCount
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[1].requiredTag
       value: 1
@@ -43256,6 +43292,18 @@ PrefabInstance:
       propertyPath: spawnRequirements.Array.data[3].requiredCount
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[0].parentTransform
+      value: 
+      objectReference: {fileID: 1127615680}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[1].parentTransform
+      value: 
+      objectReference: {fileID: 646369538}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[2].parentTransform
+      value: 
+      objectReference: {fileID: 830668616}
     - target: {fileID: 5813500355358272119, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: m_Name
       value: CrateSpawner

--- a/Project/Assets/_Data/ScriptableObjects/Collection Schedules/CollectionScheduleObject.asset
+++ b/Project/Assets/_Data/ScriptableObjects/Collection Schedules/CollectionScheduleObject.asset
@@ -15,9 +15,9 @@ MonoBehaviour:
   collectionSchedule:
   - requiredTag: 0
     requiredScore: 300
-    timeLimit: 10
+    timeLimit: 30
   - requiredTag: 1
     requiredScore: 300
-    timeLimit: 10
+    timeLimit: 30
   quotaBonusMultiplier: 1
-  totalTime: 20
+  totalTime: 60

--- a/Project/Assets/_Data/Scripts/Crates/CrateExtensions.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateExtensions.cs
@@ -8,12 +8,15 @@ using UnityEngine;
 /// </summary>
 public static class CrateExtensions
 {
-    // Struct defining any type of spawn requirement
+    // Struct defining the requirements for spawning crates
     [Serializable]
-    public struct CrateRequirement
+    public struct SpawnRequirements
     {
-        public CrateTag requiredTag;
-        public int requiredCount;
+        [Tooltip("This must be the game object whose child transforms are used as spawn points.")]
+        public Transform parentTransform;
+        public CrateTag tag;
+        public int spawnCount;
+        public int crateScore;
     }
 
     // A CrateRequirement with a time limit

--- a/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
@@ -38,7 +38,7 @@ public class CrateSpawner : MonoBehaviour
         }
     }
 
-    void Initalise()
+    void Initialise()
     {
         // Populate spawnedObjects with nodes built from each spawn requirement
         spawnedObjects = new Dictionary<SpawnNode, ICollectable>();
@@ -58,7 +58,7 @@ public class CrateSpawner : MonoBehaviour
 
     private void Awake()
     {
-        Initalise();
+        Initialise();
     }
 
     private void OnEnable()

--- a/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
@@ -14,11 +14,8 @@ public class CrateSpawner : MonoBehaviour
     [SerializeField, Range(0f, 30f)]
     float spawnInterval = 10f;
 
-    [SerializeField, Tooltip("Spawns one crate at each of the transform's children with the provided tag.")]
-    List<SpawnNode> spawnGroups;
-
     [SerializeField, Tooltip("How many objects should be spawned for a given tag.")]
-    List<CrateRequirement> spawnRequirements;
+    List<SpawnRequirements> spawnRequirements;
 
     // Maps a spawn point to its spawned object
     // This shouldn't be resizing in gameplay; its size should be predetermined in Initalise()
@@ -28,7 +25,7 @@ public class CrateSpawner : MonoBehaviour
     private void OnValidate()
     {
         // Valid prefab
-        if (cratePrefab == null || !cratePrefab.TryGetComponent<ICollectable>(out ICollectable _))
+        if (cratePrefab == null || !cratePrefab.TryGetComponent(out ICollectable _))
         {
             Debug.LogWarning("Spawner does not have correct crate prefab.");
         }
@@ -40,22 +37,20 @@ public class CrateSpawner : MonoBehaviour
         }
     }
 
-    // Populates spawnedObjects
     void Initalise()
     {
+        // Populate spawnedObjects with nodes built from each spawn requirement
         spawnedObjects = new Dictionary<SpawnNode, ICollectable>();
-
-        // Get the individual transforms in the spawn groups 
-        foreach (var group in spawnGroups)
+        foreach (var req in spawnRequirements)
         {
-            foreach (Transform t in group.transform.GetComponentInChildren<Transform>())
+            foreach (var t in req.parentTransform.GetComponentsInChildren<Transform>())
             {
-                var n = new SpawnNode()
+                var node = new SpawnNode()
                 {
-                    tag = group.tag,
-                    transform = t
+                    tag = req.tag,
+                    transform = t,
                 };
-                spawnedObjects.Add(n, null);
+                spawnedObjects.Add(node, null);
             }
         }
     }
@@ -102,18 +97,14 @@ public class CrateSpawner : MonoBehaviour
         }
         ShuffleList(spawnPoints);
 
-        // Spawn a crate at each Spawn point.
+        // Spawn a crate at each spawn point
         // Will only spawn in crates to fulfil a spawn requirement - ignores node that already meets requirements
-        foreach (SpawnNode node in spawnPoints)
+        foreach (var node in spawnPoints)
         {
-            CrateTag tag = node.tag;
-            if (GetRequirementFromTag(tag, out CrateRequirement requirement))
+            if (TryGetRequirementFromTag(node.tag, out SpawnRequirements requirement))
             {
-                if (HasMatchedRequirement(requirement)) continue;
-
-                // Spawn crate and set its tag
-                spawnedObjects[node] = Instantiate(cratePrefab, node.transform).GetComponent<ICollectable>();
-                spawnedObjects[node].Tag = tag;
+                if (WasRequirementMet(requirement)) continue;
+                SpawnCrate(node, requirement);
             }
         }
         /* Keeping this code here incase we want to revert back to quota based spawning
@@ -133,6 +124,14 @@ public class CrateSpawner : MonoBehaviour
         */
     }
 
+    // Spawns a crate and set its data based on its requirement. Instantiate within spawnedObjects
+    void SpawnCrate(in SpawnNode node, in SpawnRequirements requirement)
+    {
+        spawnedObjects[node] = Instantiate(cratePrefab, node.transform).GetComponent<ICollectable>();
+        spawnedObjects[node].Tag = node.tag;
+        spawnedObjects[node].Score = requirement.crateScore;
+    }
+
     // Randomise spawnable transforms (Fisher-Yates shuffle I found on stack overflow)
     // Partition list from 0 to pointer to end -> Select random element -> swap with pointer element -> decrement pointer
     static void ShuffleList<T>(List<T> list)
@@ -148,29 +147,27 @@ public class CrateSpawner : MonoBehaviour
     }
 
     // Returns whether a given requirement is met
-    bool HasMatchedRequirement(CrateRequirement requirement)
+    bool WasRequirementMet(SpawnRequirements requirement)
     {
         int i = 0;
-        foreach (var pair in spawnedObjects)
+        foreach (ICollectable item in spawnedObjects.Values)
         {
-            ICollectable item = pair.Value;
-
             if (item == null) continue;
-            if (item.Tag == requirement.requiredTag) i++;
-            if (i == requirement.requiredCount) break;
+            if (item.Tag == requirement.tag) i++;
+            if (i == requirement.spawnCount) break;
         }
 
-        return (i == requirement.requiredCount);
+        return (i == requirement.spawnCount);
     }
 
     // Gets a requirement from a given tag and outputs whether this requirement exists or not
-    bool GetRequirementFromTag(CrateTag tag, out CrateRequirement requirement)
+    bool TryGetRequirementFromTag(CrateTag tag, out SpawnRequirements requirement)
     {
         requirement = new();
 
         foreach (var req in spawnRequirements)
         {
-            if (req.requiredTag == tag)
+            if (req.tag == tag)
             {
                 requirement = req;
                 return true;
@@ -178,6 +175,5 @@ public class CrateSpawner : MonoBehaviour
         }
         return false;
     }
-
 
 }

--- a/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
@@ -1,18 +1,19 @@
-using System;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 using static CrateExtensions;
 
 /// <summary>
 /// MonoBehaviour which handles spawning collectable crates.
 /// </summary>
+[RequireComponent(typeof(Timer))]
 public class CrateSpawner : MonoBehaviour
 {
     [SerializeField]
     GameObject cratePrefab;
 
-    [SerializeField, Range(0f, 30f)]
-    float spawnInterval = 10f;
+    [SerializeField, Tooltip("Timeout event is assigned at runtime.")]
+    Timer timer;
 
     [SerializeField, Tooltip("How many objects should be spawned for a given tag.")]
     List<SpawnRequirements> spawnRequirements;
@@ -20,7 +21,7 @@ public class CrateSpawner : MonoBehaviour
     // Maps a spawn point to its spawned object
     // This shouldn't be resizing in gameplay; its size should be predetermined in Initalise()
     Dictionary<SpawnNode, ICollectable> spawnedObjects;
-    float timer = 0f;
+    
 
     private void OnValidate()
     {
@@ -30,10 +31,10 @@ public class CrateSpawner : MonoBehaviour
             Debug.LogWarning("Spawner does not have correct crate prefab.");
         }
 
-        // Valid range
-        if (spawnInterval < 0f)
+        if (TryGetComponent(out timer))
         {
-            spawnInterval = 0f;
+            timer.repeat = true;
+            timer.autoStart = false;
         }
     }
 
@@ -60,30 +61,27 @@ public class CrateSpawner : MonoBehaviour
         Initalise();
     }
 
-    private void Update()
+    private void OnEnable()
     {
-        bool ready = UpdateTimer();
-
-        if (ready)
+        if (timer != null)
         {
-            // Spawn crates
-            TrySpawnCrates();
+            timer.timeout.AddListener(TrySpawnCrates);
         }
     }
 
-    bool UpdateTimer()
+    private void OnDisable()
     {
-        timer += Time.deltaTime;
-        if (timer >= spawnInterval)
+        if (timer != null)
         {
-            timer = 0f;
-            return true;
+            timer.timeout.RemoveListener(TrySpawnCrates);
         }
-        return false;
     }
+
+    public void StartSpawner() => timer.paused = false;
+    public void StopSpawner() => timer.paused = true;
 
     // Attempts to spawn a crate at each point if its mapped GameObject is null
-    void TrySpawnCrates()
+    protected void TrySpawnCrates()
     {
         List<SpawnNode> spawnPoints = new();
 

--- a/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Unity.VisualScripting;
 using UnityEngine;
 using static CrateExtensions;
 


### PR DESCRIPTION
### Summary
Adjusted the crate spawner to assign the crate score of each spawn set. This means you can specify how much each crate within a spawn set is worth, so you could give different sets different scores to make some crates worth more than others. 

The inspector interface for this was also simplified, and it now relies on the `Timer` component to control spawn intervals:
<img width="656" height="616" alt="image" src="https://github.com/user-attachments/assets/3338868a-c2e9-4b31-af1e-af077d0b5287" />
(Note that the relevant event bindings and settings for the timer are done at runtime.)