### PR TITLE
Fixed audio settings

### DIFF
--- a/Project/Assets/_Data/Scenes/SplashScreen.unity
+++ b/Project/Assets/_Data/Scenes/SplashScreen.unity
@@ -358,6 +358,51 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &626863099
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 626863100}
+  - component: {fileID: 626863101}
+  m_Layer: 0
+  m_Name: AudioMixerSetup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &626863100
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626863099}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &626863101
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626863099}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fa9aae8cd36d6a488d9ea371796fea6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: fb7fa2da7aa779b4fa07dec20a1c0ed2, type: 2}
 --- !u!1 &723237211
 GameObject:
   m_ObjectHideFlags: 0
@@ -399,7 +444,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 723237211}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -524,7 +569,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2086496083}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -615,3 +660,4 @@ SceneRoots:
   - {fileID: 1108831881}
   - {fileID: 2086496085}
   - {fileID: 723237213}
+  - {fileID: 626863100}

--- a/Project/Assets/_Data/Scripts/Audio/AudioMixerSetup.cs
+++ b/Project/Assets/_Data/Scripts/Audio/AudioMixerSetup.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using UnityEngine.Audio;
+
+/// <summary>
+/// Setups up the Audio Mixer values after the Save Manager has finished loading
+/// </summary>
+public class AudioMixerSetup : MonoBehaviour
+{
+	[SerializeField] private AudioMixer audioMixer;
+	
+    private void Start()
+    {
+        // Subscribe to events
+		SaveManager.onLoaded.AddListener(Init);
+    }
+	
+	private void Init()
+	{
+		// The slider is linear and the AudioMixer is logarithmic - see JLF comment - https://forum.unity.com/threads/changing-audio-mixer-group-volume-with-ui-slider.297884/
+		audioMixer.SetFloat("SFX", Mathf.Log(SaveManager.instance.currentSaveData.audio.sfxVolume) * 20);
+		audioMixer.SetFloat("Music", Mathf.Log(SaveManager.instance.currentSaveData.audio.musicVolume) * 20);
+		
+	}
+}

--- a/Project/Assets/_Data/Scripts/Audio/AudioMixerSetup.cs.meta
+++ b/Project/Assets/_Data/Scripts/Audio/AudioMixerSetup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7fa9aae8cd36d6a488d9ea371796fea6

--- a/Project/Assets/_Data/Scripts/UI/OptionsMenu/VolumeSlider.cs
+++ b/Project/Assets/_Data/Scripts/UI/OptionsMenu/VolumeSlider.cs
@@ -48,7 +48,10 @@ public class VolumeSlider : MonoBehaviour
 				
 				// Persist for future playthroughs
 				if (SaveManager.instance)
+				{
 					SaveManager.instance.currentSaveData.audio.sfxVolume = slider.value;
+					SaveManager.instance.Save();
+				}
 				
 				break;
 			
@@ -58,7 +61,10 @@ public class VolumeSlider : MonoBehaviour
 				
 				// Persist for future playthroughs
 				if (SaveManager.instance)
+				{
 					SaveManager.instance.currentSaveData.audio.musicVolume = slider.value;
+					SaveManager.instance.Save();
+				}
 				
 				break;
 				


### PR DESCRIPTION
When the game loads it now assigns the Save Data audio values to the Audio Mixer

When a slider changes value it now saves. Pressing the B button caused it not to save (no button click)