### PR TITLE
New contextual prompt system part 1 - Prompts near crates

### DIFF
--- a/Project/Assets/_Data/Prefabs/Custom/ContextualPromptListener.prefab
+++ b/Project/Assets/_Data/Prefabs/Custom/ContextualPromptListener.prefab
@@ -1,0 +1,74 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1369848368880762661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2736452311419991666}
+  - component: {fileID: 6331252079913013168}
+  - component: {fileID: 6269254965424841567}
+  m_Layer: 0
+  m_Name: ContextualPromptListener
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2736452311419991666
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369848368880762661}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6331252079913013168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369848368880762661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6acae4ae497975640be09245982a6c85, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  areaCollider: {fileID: 6269254965424841567}
+  messageUI: {fileID: 0}
+  boxCastSize: 1
+  boxCastDistance: 3
+--- !u!136 &6269254965424841567
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369848368880762661}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Project/Assets/_Data/Prefabs/Custom/ContextualPromptListener.prefab.meta
+++ b/Project/Assets/_Data/Prefabs/Custom/ContextualPromptListener.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7d9d7f1cdeff3d44f9db5a17483b7524
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project/Assets/_Data/Prefabs/Custom/ContextualPromptSource.prefab
+++ b/Project/Assets/_Data/Prefabs/Custom/ContextualPromptSource.prefab
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4041603673225497426
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4128071706123077391}
+  - component: {fileID: 6189227492589467029}
+  m_Layer: 6
+  m_Name: ContextualPromptSource
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4128071706123077391
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4041603673225497426}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6189227492589467029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4041603673225497426}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b400159318dfec44c8214d58497fe116, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  areaCollider: {fileID: 0}
+  showExclusivelyOnCast: 0
+  message: 

--- a/Project/Assets/_Data/Prefabs/Custom/ContextualPromptSource.prefab.meta
+++ b/Project/Assets/_Data/Prefabs/Custom/ContextualPromptSource.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4201db5a7a0c7034688542e82df07d57
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project/Assets/_Data/Prefabs/Environment/Crates/InteractableCrate.prefab
+++ b/Project/Assets/_Data/Prefabs/Environment/Crates/InteractableCrate.prefab
@@ -219,6 +219,7 @@ Transform:
   - {fileID: 8224265301878430043}
   - {fileID: 5372889075528984419}
   - {fileID: 7488848179007587622}
+  - {fileID: 8662379853566551946}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &5113504707291311347
@@ -1362,3 +1363,94 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 8013467744136765063}
   m_maskType: 0
+--- !u!1001 &4719543489935384709
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 852655544728036825}
+    m_Modifications:
+    - target: {fileID: 1297429675461987104, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_Radius
+      value: 0.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 4041603673225497426, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_Name
+      value: ContextualPromptSource
+      objectReference: {fileID: 0}
+    - target: {fileID: 4041603673225497426, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6189227492589467029, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: message
+      value: <sprite name="Xbox_Y"> Grab
+      objectReference: {fileID: 0}
+    - target: {fileID: 6189227492589467029, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: showOnCast
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6189227492589467029, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: areaCollider
+      value: 
+      objectReference: {fileID: 799914299884088629}
+    - target: {fileID: 6189227492589467029, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: showOnTrigger
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6189227492589467029, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+      propertyPath: showExclusivelyOnCast
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 1297429675461987104, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+--- !u!4 &8662379853566551946 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4128071706123077391, guid: 4201db5a7a0c7034688542e82df07d57, type: 3}
+  m_PrefabInstance: {fileID: 4719543489935384709}
+  m_PrefabAsset: {fileID: 0}

--- a/Project/Assets/_Data/Prefabs/Player/Forklift.prefab
+++ b/Project/Assets/_Data/Prefabs/Player/Forklift.prefab
@@ -6245,7 +6245,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &8946032051519497768
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6277,8 +6277,8 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 1
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 0.22
+  m_Camera: {fileID: 8822135357838566119}
+  m_PlaneDistance: 0.5
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
   m_OverrideSorting: 0
@@ -12019,6 +12019,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 4670194306561086270}
   - {fileID: 4773819098820074584}
   - {fileID: 4984584100628000045}
   - {fileID: 4772259750914084470}
@@ -13335,6 +13336,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4283527512771772, guid: e332982425ee2ec48b168979bb7b43f5, type: 3}
   m_PrefabInstance: {fileID: 3206120660688725181}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7293025556958553420
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4860262084814405887}
+    m_Modifications:
+    - target: {fileID: 1369848368880762661, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_Name
+      value: ContextualPromptListener
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.775
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.502
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6269254965424841567, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_Height
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6269254965424841567, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_Radius
+      value: 2.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 6269254965424841567, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_Center.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6269254965424841567, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: m_Center.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6331252079913013168, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: messageUI
+      value: 
+      objectReference: {fileID: 7355957186543924399}
+    - target: {fileID: 6331252079913013168, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: boxCastSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6331252079913013168, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+      propertyPath: boxCastDistance
+      value: 1.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+--- !u!4 &4670194306561086270 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2736452311419991666, guid: 7d9d7f1cdeff3d44f9db5a17483b7524, type: 3}
+  m_PrefabInstance: {fileID: 7293025556958553420}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7867455018986137580
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13409,7 +13500,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1181428647940724701, guid: db39bd2a86674f1479055cce9386e0d2, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -170
       objectReference: {fileID: 0}
     - target: {fileID: 1181428647940724701, guid: db39bd2a86674f1479055cce9386e0d2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -13519,7 +13610,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1181428647940724701, guid: db39bd2a86674f1479055cce9386e0d2, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -170
       objectReference: {fileID: 0}
     - target: {fileID: 1181428647940724701, guid: db39bd2a86674f1479055cce9386e0d2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -13550,6 +13641,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: db39bd2a86674f1479055cce9386e0d2, type: 3}
+--- !u!114 &7355957186543924399 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1970488738501569880, guid: db39bd2a86674f1479055cce9386e0d2, type: 3}
+  m_PrefabInstance: {fileID: 9028882754198411767}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &7865622647028026922 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1181428647940724701, guid: db39bd2a86674f1479055cce9386e0d2, type: 3}

--- a/Project/Assets/_Data/Scenes/AlphaLevel/AlphaLevel.unity
+++ b/Project/Assets/_Data/Scenes/AlphaLevel/AlphaLevel.unity
@@ -9836,6 +9836,10 @@ PrefabInstance:
       value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 3278701883763776178, guid: 8dc9ed0b39b496941a65dfb493fa3664, type: 3}
+      propertyPath: debugPlayerCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278701883763776178, guid: 8dc9ed0b39b496941a65dfb493fa3664, type: 3}
       propertyPath: playerJoined.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
@@ -24747,9 +24751,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fec9a6f99e09b904ba6e09feb396d46c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sprite: {fileID: 21300000, guid: b171b9200c595404e8ba78cb3d13d97b, type: 3}
-  color: {r: 0.32334462, g: 0.6037736, b: 0, a: 1}
-  registerOnAwake: 1
 --- !u!114 &1149637565 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3022961426910664996, guid: a66a47a91cf3e754898bb014ddcbcc43, type: 3}

--- a/Project/Assets/_Data/Scenes/NewLevel1.unity
+++ b/Project/Assets/_Data/Scenes/NewLevel1.unity
@@ -1689,7 +1689,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3278701883763776178, guid: 8dc9ed0b39b496941a65dfb493fa3664, type: 3}
       propertyPath: debug_mode_on
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3278701883763776178, guid: 8dc9ed0b39b496941a65dfb493fa3664, type: 3}
       propertyPath: forklift_mesh

--- a/Project/Assets/_Data/Scripts/Crates/CrateObject.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateObject.cs
@@ -18,23 +18,26 @@ public class CrateObject : MonoBehaviour, ICollectable
     bool useColouredTags = true;
 
     bool collect;
+    string startingPromptText;
+    ContextualPromptSource promptSource;
     MaterialPropertyBlock block;
     PhysicsPickup pickup;
     TextMeshPro[] textObjects;
 
     private void Awake()
     {
+        textObjects = GetComponentsInChildren<TextMeshPro>();
+        promptSource = GetComponentInChildren<ContextualPromptSource>();
         block = new MaterialPropertyBlock();
         collect = true;
-        
+        startingPromptText = "<sprite name=\"Xbox_Y\">";
+
         // Bind grabbing event to pickup controller
         if (!TryGetComponent(out pickup))
         {
             Debug.LogWarning("No PhysicsPickup on CrateObject");
         }
 
-        // Get textObjects
-        textObjects = GetComponentsInChildren<TextMeshPro>();
     }
 
     private void OnEnable()
@@ -57,13 +60,49 @@ public class CrateObject : MonoBehaviour, ICollectable
 
     public float Score
     {
-        get => score; 
-        set  
-        { 
+        get => score;
+        set
+        {
             score = value;
             UpdateTextObjects();
-        } 
+        }
     }
+
+    public CrateTag Tag
+    {
+        get { return crateTag; }
+        set
+        {
+            crateTag = value;
+            if (!useColouredTags) return;
+
+            // Colour this object based on its tag
+            var renderer = GetComponent<Renderer>();
+            renderer.GetPropertyBlock(block);
+            block.SetColor("_BaseColor", value.GetColourFromTag());
+            renderer.SetPropertyBlock(block);
+        }
+    }
+
+    public GameObject GameObject { get => gameObject; }
+
+    public bool CanCollect
+    {
+        get => collect;
+        set => collect = value;
+    }
+
+    // Make the object collect-able or not
+    void OnGrabbed()
+    {
+        CanCollect = false;
+        UpdatePromptTextToDrop();
+    }
+    void OnDropped() 
+    { 
+        CanCollect = true;
+        UpdatePromptTextToGrab();
+    } 
 
     // Displays the current score in the textObjects
     void UpdateTextObjects()
@@ -74,31 +113,18 @@ public class CrateObject : MonoBehaviour, ICollectable
         }
     }
 
-    public CrateTag Tag
+    // Particularly ugly ways to change the prompt text
+    void UpdatePromptTextToGrab()
     {
-        get { return crateTag; }
-        set 
-        { 
-            crateTag = value;
-            if (!useColouredTags) return;
+        if (promptSource == null) return;
 
-            // Colour this object based on its tag
-            var renderer = GetComponent<Renderer>();
-            renderer.GetPropertyBlock(block);
-            block.SetColor("_BaseColor", value.GetColourFromTag());
-            renderer.SetPropertyBlock(block);
-        } 
+        promptSource.message = $"{startingPromptText} Grab";
     }
 
-    public GameObject GameObject { get => gameObject; }
+    void UpdatePromptTextToDrop()
+    {
+        if (promptSource == null) return;
 
-    public bool CanCollect 
-    { 
-        get => collect; 
-        set => collect = value; 
+        promptSource.message = $"{startingPromptText} Drop";
     }
-
-    // Make the object collect-able or not
-    void OnGrabbed() => CanCollect = false;
-    void OnDropped() => CanCollect = true;
 }

--- a/Project/Assets/_Data/Scripts/Environment/ContextualPromptListener.cs
+++ b/Project/Assets/_Data/Scripts/Environment/ContextualPromptListener.cs
@@ -1,0 +1,140 @@
+using System;
+using TMPro;
+using UnityEngine;
+
+/// <summary>
+/// Listener for contextual prompts, displaying their message to the relevant target.
+/// </summary>
+public class ContextualPromptListener : MonoBehaviour
+{
+    /* NOTE THAT THE CURRENT DISPLAY FOR THIS IS TEMPORARY:
+     * The display should be handled by the ContextualPromptSource, not the the listener.
+     * Right now the listener will display the text using the old system (Similar to PlayerShowMessageController)
+     */
+
+    [SerializeField]
+    Collider areaCollider;
+
+    [SerializeField]
+    TextMeshProUGUI messageUI;
+
+    [SerializeField]
+    float boxCastSize = 1f;
+
+    [SerializeField]
+    float boxCastDistance = 3f;
+
+    RaycastHit hit;
+    ContextualPromptSource currentFocus, castSource, triggerSource;
+
+    private void OnValidate()
+    {
+        if (areaCollider == null)
+        {
+            TryGetComponent(out areaCollider);
+        }
+    }
+
+    private void Awake()
+    {
+        currentFocus = triggerSource = null;
+    }
+
+    private void FixedUpdate()
+    {
+        CastBox();
+        if (currentFocus != null)
+        {
+            DisplayPrompt(currentFocus);
+        }
+        else
+        {
+            HidePrompt();
+        }
+    }
+
+    /* Source detection behaviour:
+    BoxCast to find sources in front, collider to find sources nearby.
+    Behaviour:
+        - For that source detection find a source
+        - If there is a source, if we do not have a focus assign that new source as the focus
+        - If there is no source, declare this source detection has returned null, if the other source detection was null then clear the focus
+     */
+
+    // Does a BoxCast to see if there's any sources to trigger
+    private void CastBox()
+    {
+        var success = Physics.BoxCast(transform.position, 0.5f * boxCastSize * transform.localScale, transform.forward, out hit, transform.rotation, boxCastDistance);
+        if (success)
+        {
+            // Get the prompt source and assign to focus if we don't have one
+            if (TryFindSourceInObject(hit.collider.gameObject, out var source))
+            {
+                Debug.Log("Hit a prompt source");
+                if (source.ShowOnCast)
+                {
+                    castSource = source;
+                    if (currentFocus == null) currentFocus = castSource;
+                }
+            }
+        }
+        else
+        {
+            // Mark no source found; clear focus if the other check is empty.
+            castSource = null;
+            if (triggerSource == null) currentFocus = null;
+        }
+    }
+
+    // Only assign a new trigger source if we do not already have one
+    private void OnTriggerEnter(Collider other)
+    {
+        if (triggerSource != null) return;
+
+        // Check for this and its children
+        if(TryFindSourceInObject(other.gameObject, out var source))
+        {
+            if (source.ShowOnTrigger)
+            {
+                triggerSource = source;
+                if (currentFocus == null) currentFocus = triggerSource;
+            }
+        }
+    }
+
+    // When exiting a trigger, always mark the trigger source as null
+    private void OnTriggerExit(Collider other)
+    {
+        if (TryFindSourceInObject(other.gameObject, out _))
+        {
+            triggerSource = null;
+            if (castSource == null) currentFocus = null;
+        }
+    }
+
+    // Checks if the source is on the object or a child of the object
+    bool TryFindSourceInObject(GameObject gameObject, out ContextualPromptSource source)
+    {
+        if (!gameObject.TryGetComponent(out source))
+        {
+            source = gameObject.GetComponentInChildren<ContextualPromptSource>();
+            if (source == null) return false;
+        }
+
+        return true;
+    }
+
+    // Display's the message of the given prompt source
+    void DisplayPrompt(ContextualPromptSource source)
+    {
+        messageUI.SetText(source.message);
+        messageUI.gameObject.SetActive(true);
+    }
+
+    void HidePrompt()
+    {
+        messageUI.SetText("");
+        messageUI.gameObject.SetActive(false);
+    }
+
+}

--- a/Project/Assets/_Data/Scripts/Environment/ContextualPromptListener.cs.meta
+++ b/Project/Assets/_Data/Scripts/Environment/ContextualPromptListener.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6acae4ae497975640be09245982a6c85

--- a/Project/Assets/_Data/Scripts/Environment/ContextualPromptSource.cs
+++ b/Project/Assets/_Data/Scripts/Environment/ContextualPromptSource.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+/// <summary>
+/// Source object for displaying a contextual prompt. A ContextualPromptListener will detect this
+/// </summary>
+public class ContextualPromptSource : MonoBehaviour
+{
+    // SIMPLE IMPLEMENTATION i want this to be expanded on later
+    // Because of that some of the things here are gonna go unused for a bit
+
+    [SerializeField, Tooltip("If the prompt should appear with ray/box casts.")]
+    bool showOnCast = false;
+
+    [SerializeField, Tooltip("If the prompt should appear with trigger collisions")]
+    bool showOnTrigger = false;
+
+    [TextArea]
+    public string message = "";
+
+    public bool ShowOnCast => showOnCast;
+    public bool ShowOnTrigger => showOnTrigger;
+}

--- a/Project/Assets/_Data/Scripts/Environment/ContextualPromptSource.cs.meta
+++ b/Project/Assets/_Data/Scripts/Environment/ContextualPromptSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b400159318dfec44c8214d58497fe116


### PR DESCRIPTION
### Description
This is a smaller part of a larger change for a new system to display contextual prompts whenever the players are near something interactable. In this new system, button prompts will appear next to relevant interactable objects and any potential on-screen controls may show or hide themselves.

What is currently present are the 'source' and 'listener' objects for this system. The goal is that a listener object can detect source objects and cause them to display their relevant prompts, expected to be either in world space or on the screen. Right now this is emulating the previous prompt system but with new text.

### Images
<img width="1363" height="712" alt="image" src="https://github.com/user-attachments/assets/3f895b05-837b-4f6a-837d-ad2eb9b18c2e" />