### PR TITLE
Improve crate damage customisability by moving this data to spawner

### DIFF
--- a/Project/Assets/_Data/Scenes/NewLevel1.unity
+++ b/Project/Assets/_Data/Scenes/NewLevel1.unity
@@ -7761,7 +7761,7 @@ PrefabInstance:
       objectReference: {fileID: 830668616}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[0].crateScore
-      value: 50
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[0].spawnCount
@@ -7769,7 +7769,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[1].crateScore
-      value: 50
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[1].spawnCount
@@ -7777,7 +7777,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[2].crateScore
-      value: 50
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[2].spawnCount
@@ -7785,7 +7785,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[3].crateScore
-      value: 30
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[3].spawnCount
@@ -7793,7 +7793,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[4].crateScore
-      value: 30
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[4].spawnCount
@@ -7801,7 +7801,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[5].crateScore
-      value: 30
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: spawnRequirements.Array.data[5].spawnCount
@@ -7859,6 +7859,90 @@ PrefabInstance:
       propertyPath: spawnRequirements.Array.data[5].parentTransform
       value: 
       objectReference: {fileID: 148736678}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[0].damageBehaviour.damageCoefficient
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[1].damageBehaviour.damageCoefficient
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[2].damageBehaviour.damageCoefficient
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[3].damageBehaviour.damageCoefficient
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[4].damageBehaviour.damageCoefficient
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[5].damageBehaviour.damageCoefficient
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[0].damageBehaviour.maximumScoreLossValue
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[1].damageBehaviour.maximumScoreLossValue
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[2].damageBehaviour.maximumScoreLossValue
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[3].damageBehaviour.maximumScoreLossValue
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[4].damageBehaviour.maximumScoreLossValue
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[5].damageBehaviour.maximumScoreLossValue
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[2].damageBehaviour.maximumScoreLossPercentage
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[3].damageBehaviour.maximumScoreLossPercentage
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[5].damageBehaviour.maximumScoreLossPercentage
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[0].damageBehaviour.collisionVelocityForCrateDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[1].damageBehaviour.collisionVelocityForCrateDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[2].damageBehaviour.collisionVelocityForCrateDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[3].damageBehaviour.collisionVelocityForCrateDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[4].damageBehaviour.collisionVelocityForCrateDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4649749589772436556, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
+      propertyPath: spawnRequirements.Array.data[5].damageBehaviour.collisionVelocityForCrateDamage
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 5813500355358272119, guid: afaec8739684c6744bf4ce5e2dd4b54b, type: 3}
       propertyPath: m_Name
       value: CrateSpawner

--- a/Project/Assets/_Data/Scripts/Crates/CrateExtensions.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateExtensions.cs
@@ -19,6 +19,7 @@ public static class CrateExtensions
         public CrateTag tag;
         public int spawnCount;
         public int crateScore;
+        public DamageBehaviour damageBehaviour;
 
         /// <summary>
         /// Map of spawn points and the crate they are parented to
@@ -34,8 +35,25 @@ public static class CrateExtensions
         // Also this whole system might have a memory leak LOL
     }
 
+    // Damage behaviour information for calculating crate damage
+    [Serializable]
+    public struct DamageBehaviour
+    {
+        [Tooltip("Collision velocity threshold for the crate to take damage. Higher values means the crate's velocity must be higher when colliding for damage.")]
+        public float collisionVelocityForCrateDamage;
 
-    // A CrateRequirement with a time limit
+        [Tooltip("Damage multiplier, applied to the collision velocity above the collisionVelocityForCrateDamage threshold.")]
+        public float damageCoefficient;
+
+        [Tooltip("Maximum damage the crate can take as a numerical value."), Min(0f)]
+        public float maximumScoreLossValue;
+
+        [Tooltip("Maximum damage the crate can take as a percentage of the crate's maximum score."), Range(0f, 1f)]
+        public float maximumScoreLossPercentage;
+
+    }
+
+    // A quota that the players must complete
     [Serializable]
     public struct ScheduleQuota
     {

--- a/Project/Assets/_Data/Scripts/Crates/CrateObject.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateObject.cs
@@ -1,7 +1,6 @@
 using TMPro;
 using UnityEngine;
 using static CrateExtensions;
-using static UnityEngine.Rendering.DebugUI;
 
 /// <summary>
 ///  This class is mostly for demonstration.
@@ -19,19 +18,6 @@ public class CrateObject : MonoBehaviour, ICollectable
     [SerializeField]
     bool useColouredTags = true;
 
-    [Header("Crate damage behaviour")]
-    [SerializeField, Min(0f)]
-    float collisionVelocityForCrateDamage = 10f;
-
-    [SerializeField, Min(0f)]
-    float damageCoefficient = 1f;
-
-    [SerializeField, Tooltip("Values are combined to define the maximum loss from damage.")]
-    float maximumScoreLossValue = 10f;
-
-    [SerializeField, Tooltip("Values are combined to define the maximum loss from damage."), Range(0f, 1f)]
-    float maximumScoreLossPercentage = 0f;
-
     float maxScore;
     bool collect;
     string startingPromptText;
@@ -41,7 +27,7 @@ public class CrateObject : MonoBehaviour, ICollectable
     TextMeshPro[] textObjects;
 
     // As in the minimum score the crate can have
-    float MaximumScoreReduction => maxScore * (1 - maximumScoreLossPercentage) - maximumScoreLossValue;
+    float MaximumScoreReduction => maxScore * (1 - DamageBehaviour.maximumScoreLossPercentage) - DamageBehaviour.maximumScoreLossValue;
 
     /// <summary>
     /// Instantiate and initialise a new crate.
@@ -51,11 +37,12 @@ public class CrateObject : MonoBehaviour, ICollectable
     /// <param name="crateTag">Tag for the crate.</param>
     /// <param name="score">Starting score of the crate.</param>
     /// <returns></returns>
-    public static ICollectable Instantiate(GameObject prefab, Transform transform, CrateTag crateTag, float score)
+    public static ICollectable Instantiate(GameObject prefab, Transform transform, CrateTag crateTag, DamageBehaviour damageBehaviour, float score)
     {
         var collectable = Instantiate(prefab, transform).GetComponent<ICollectable>();
         collectable.Tag = crateTag;
         collectable.Score = collectable.MaxScore = score;
+        collectable.DamageBehaviour = damageBehaviour;
         return collectable;
     }
 
@@ -97,7 +84,7 @@ public class CrateObject : MonoBehaviour, ICollectable
     private void OnCollisionEnter(Collision collision)
     {
         var relativeVelocity = collision.relativeVelocity;
-        if (relativeVelocity.magnitude > collisionVelocityForCrateDamage)
+        if (relativeVelocity.magnitude > DamageBehaviour.collisionVelocityForCrateDamage)
         {
             DamageCrate(collision, relativeVelocity);
         }
@@ -130,6 +117,8 @@ public class CrateObject : MonoBehaviour, ICollectable
             if (useColouredTags) RecolourCrate();
         }
     }
+
+    public DamageBehaviour DamageBehaviour { get; set; }
 
     public GameObject GameObject { get => gameObject; }
 
@@ -188,7 +177,7 @@ public class CrateObject : MonoBehaviour, ICollectable
     }
 
     // Returns how much score would be lost based on the relative velocity of a collision
-    float GetScoreLoss(Vector3 relativeVelocity) => (relativeVelocity.magnitude - collisionVelocityForCrateDamage) * damageCoefficient;
+    float GetScoreLoss(Vector3 relativeVelocity) => (relativeVelocity.magnitude - DamageBehaviour.collisionVelocityForCrateDamage) * DamageBehaviour.damageCoefficient;
 
     // Displays the current score in the textObjects
     void UpdateTextObjects()

--- a/Project/Assets/_Data/Scripts/Crates/CrateObject.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateObject.cs
@@ -88,7 +88,7 @@ public class CrateObject : MonoBehaviour, ICollectable
         var relativeVelocity = collision.relativeVelocity;
         if (relativeVelocity.magnitude > DamageBehaviour.collisionVelocityForCrateDamage)
         {
-            DamageCrate(collision, relativeVelocity);
+            DamageCrate(relativeVelocity);
         }
     }
 
@@ -152,16 +152,17 @@ public class CrateObject : MonoBehaviour, ICollectable
     }
 
     // Reduces the crate's score and displays the text for that
-    private void DamageCrate(Collision collision, Vector3 relativeVelocity)
+    private void DamageCrate(Vector3 relativeVelocity)
     {
         // Handle literal scores as integers - cast as int
+        float temp = Score;
         float damage = (int)GetScoreLoss(relativeVelocity);
         Score = (int)Mathf.Max(MaximumScoreReduction, Score - damage);
-        InstanceDamageText(collision.transform.position, damage);
+        if (score != temp) InstanceDamageText(damage);
     }
 
     // Creates text representing damage that the crate will take
-    private void InstanceDamageText(Vector3 position, float damage)
+    private void InstanceDamageText(float damage)
     {
         if (damage > 0)
         {

--- a/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
@@ -15,7 +15,7 @@ public class CrateSpawner : MonoBehaviour
     [SerializeField, Tooltip("Timeout event is assigned at runtime.")]
     Timer timer;
 
-    [SerializeField, Tooltip("How many objects should be spawned for a given tag.")]
+    [SerializeField, Tooltip("How many objects should be spawned for a given tag."), ContextMenuItem("Apply default damage behaviour", "ResetAllDamageBehaviours")]
     List<SpawnRequirements> spawnRequirements;
 
     private void OnValidate()
@@ -95,7 +95,7 @@ public class CrateSpawner : MonoBehaviour
 
     // Spawns a crate and set its data based on its requirement. Instantiate within spawnedObjects
     void SpawnCrate(in Transform point, in SpawnRequirements requirement) 
-        => requirement.instances[point] = CrateObject.Instantiate(cratePrefab, point, requirement.tag, requirement.crateScore);
+        => requirement.instances[point] = CrateObject.Instantiate(cratePrefab, point, requirement.tag, requirement.damageBehaviour, requirement.crateScore);
 
     // Randomise spawnable transforms (Fisher-Yates shuffle I found on stack overflow)
     // Partition list from 0 to pointer to end -> Select random element -> swap with pointer element -> decrement pointer
@@ -121,6 +121,21 @@ public class CrateSpawner : MonoBehaviour
                 Gizmos.color = req.tag.GetColourFromTag();
                 Gizmos.DrawCube(t.position, new Vector3(1, 1, 1) * (req.crateScore / 75f));
             }
+        }
+    }
+
+    // UTILITY FUNCTION
+    private void ResetAllDamageBehaviours()
+    {
+        foreach(var req in spawnRequirements)
+        {
+            req.damageBehaviour = new()
+            {
+                collisionVelocityForCrateDamage = 10f,
+                damageCoefficient = 0.4f,
+                maximumScoreLossValue = 10f,
+                maximumScoreLossPercentage = 0f
+            };
         }
     }
 }

--- a/Project/Assets/_Data/Scripts/Interfaces/ICollectable.cs
+++ b/Project/Assets/_Data/Scripts/Interfaces/ICollectable.cs
@@ -10,6 +10,7 @@ public interface ICollectable
     public float Score { get; set; }
     public bool CanCollect { get; set; }
     public GameObject GameObject { get; }
+    public CrateExtensions.DamageBehaviour DamageBehaviour { get; set; }
     public CrateExtensions.CrateTag Tag { get; set; }
 
 }


### PR DESCRIPTION
### Summary

Moves the crate's damage-related data into the spawner using a new `CrateExtensions.DamageBehaviour` struct. This means that different groups of crates can have their damage behaviour customised to make them more durable or more fragile. All of this data was previously on the crate prefab, which is now no longer the case.