### PR TITLE
Crates can't be stolen from other players

### DIFF
--- a/Project/Assets/_Data/Scenes/Level 1/Level 1.unity
+++ b/Project/Assets/_Data/Scenes/Level 1/Level 1.unity
@@ -7325,7 +7325,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3278701883763776178, guid: 8dc9ed0b39b496941a65dfb493fa3664, type: 3}
       propertyPath: debugPlayerCount
-      value: 4
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3278701883763776178, guid: 8dc9ed0b39b496941a65dfb493fa3664, type: 3}
       propertyPath: playerJoined.m_PersistentCalls.m_Calls.Array.size

--- a/Project/Assets/_Data/Scripts/Crates/CrateObject.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateObject.cs
@@ -139,10 +139,12 @@ public class CrateObject : MonoBehaviour, ICollectable
     void OnGrabbed()
     {
         UpdatePromptTextToDrop();
+        CanCollect = false;
     }
     void OnDropped() 
     { 
         UpdatePromptTextToGrab();
+        CanCollect = true;
     }
 
     // Reduces the crate's score and displays the text for that

--- a/Project/Assets/_Data/Scripts/Interactions/ForkliftPickup/CratePickUp.cs
+++ b/Project/Assets/_Data/Scripts/Interactions/ForkliftPickup/CratePickUp.cs
@@ -77,7 +77,7 @@ public class CratePickUp : MonoBehaviour
     private void OnTriggerEnter(Collider other)
     {
         //if the other object is a box and the current player isn't holding a forklift
-        if (other.tag == "Float" && !holdingForklift)
+        if (other.tag == "Float" && !holdingForklift && other.GetComponent<ICollectable>().CanCollect)
         {
             interactionUIText.gameObject.SetActive(true);
             if (heldObjects.Count > 0 && !heldObjects.Contains(other.gameObject))
@@ -115,7 +115,7 @@ public class CratePickUp : MonoBehaviour
 
     public void PickUpSelected()
     { 
-        if(forkLiftSelected || holdingForklift)
+        if(forkLiftSelected || holdingForklift || !pickupList[0].GetComponent<ICollectable>().CanCollect)
             return;
 
         if(pickupList.Count == 0 && heldObjects.Count == 0)
@@ -156,7 +156,6 @@ public class CratePickUp : MonoBehaviour
         SetForkliftPostitionInParent(Angle);
 
         holdingForklift = true;
-
     }
 
     public void DropHeld()

--- a/Project/Assets/_Data/Scripts/Interfaces/ICollectable.cs
+++ b/Project/Assets/_Data/Scripts/Interfaces/ICollectable.cs
@@ -8,6 +8,7 @@ public interface ICollectable
 {
     public float MaxScore { get; set; }
     public float Score { get; set; }
+    //CanCollect is being used to determine if the object  is held currently
     public bool CanCollect { get; set; }
     public bool CanDamage { get; set; }
     public GameObject GameObject { get; }


### PR DESCRIPTION
To stop the bugs crate stealing causes, for now the player can not take other players crates
