### PR TITLE
Randomise quota's required tag 

### DIFF
--- a/Project/Assets/_Data/ScriptableObjects/Collection Schedules/CollectionScheduleObject.asset
+++ b/Project/Assets/_Data/ScriptableObjects/Collection Schedules/CollectionScheduleObject.asset
@@ -23,5 +23,6 @@ MonoBehaviour:
     requiredScore: 200
     timeLimit: 100
   quotaBonusMultiplier: 1
-  actingScheduler: {fileID: 0}
+  randomiseRequiredTag: 1
   totalTime: 300
+  actingScheduler: {fileID: 0}

--- a/Project/Assets/_Data/Scripts/Crates/CollectionScheduleObject.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CollectionScheduleObject.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using UnityEngine;
 using static CrateExtensions;
+using System.Linq;
 
 /// <summary>
 /// Contains the schedule for how a collector should collect crates
@@ -10,21 +12,26 @@ public class CollectionScheduleObject : ScriptableObject
     [SerializeField]
     ScheduleQuota[] collectionSchedule;
 
+    [SerializeField, Tooltip("Whether this schedule object's tag requirements should be randomised.")]
+    bool randomiseRequiredTag = false;
+
     [SerializeField, Min(1f)]
     float quotaBonusMultiplier = 1f;
 
-    public ScheduleQuota[] CollectionSchedule => collectionSchedule;
 
     [Tooltip("Score multiplier if the quota is met.")]
     public float QuotaBonusMultiplier => quotaBonusMultiplier;
-
-    [HideInInspector]
-    public CollectorScheduler actingScheduler;
 
     // This should use some special attribute so it's not editable in the inspector
     [SerializeField]
     float totalTime = 0f;
 
+    [HideInInspector]
+    public CollectorScheduler actingScheduler;
+
+    [HideInInspector]
+    public bool RandomiseRequiredTag => randomiseRequiredTag;
+    public ScheduleQuota[] CollectionSchedule => collectionSchedule;
     public float TotalTime => totalTime;
 
     private void OnValidate()
@@ -32,5 +39,24 @@ public class CollectionScheduleObject : ScriptableObject
         float t = 0f;
         foreach (var r in collectionSchedule) t += r.timeLimit;
         totalTime = t;
+    }
+
+    /// <summary>
+    /// Randomises each <see cref="ScheduleQuota.requiredTag"/> in <see cref="CollectionSchedule"/>. This is dependent on how many objects are
+    /// in that array, and what <see cref="CrateTag"/>s are in that array. This function should only be called once - it will edit this asset's 
+    /// data directly which may desynchronise other scripts which may depend on this data.
+    /// </summary>
+    public void RandomiseTags()
+    {
+        // Get a list of all the current tags in the schedule and randomise them
+        List<CrateTag> tags = new();
+        tags.AddRange(collectionSchedule.Select(quota => quota.requiredTag));
+        ShuffleList(tags);
+
+        // Apply shuffled tags
+        for (int i = 0; i < collectionSchedule.Length; i++)
+        {
+            collectionSchedule[i].requiredTag = tags[i];
+        }
     }
 }

--- a/Project/Assets/_Data/Scripts/Crates/CollectorScheduler.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CollectorScheduler.cs
@@ -88,8 +88,10 @@ public class CollectorScheduler : MonoBehaviour
     void SetSchedule()
     {
         if (scheduleObject == null) return;
+        if (scheduleObject.RandomiseRequiredTag) scheduleObject.RandomiseTags();
 
         Schedule = new Queue<ScheduleQuota>();
+
         foreach (var req in scheduleObject.CollectionSchedule)
         {
             Schedule.Enqueue(req);

--- a/Project/Assets/_Data/Scripts/Crates/CrateExtensions.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateExtensions.cs
@@ -95,4 +95,18 @@ public static class CrateExtensions
         };
     }
 
+    // Randomise spawnable transforms (Fisher-Yates shuffle I found on stack overflow)
+    // Partition list from 0 to pointer to end -> Select random element -> swap with pointer element -> decrement pointer
+    public static void ShuffleList<T>(List<T> list)
+    {
+        var rnd = new System.Random();
+        int n = list.Count;
+        while (n > 1)
+        {
+            n--;
+            int k = rnd.Next(0, n + 1);
+            (list[n], list[k]) = (list[k], list[n]);
+        }
+    }
+
 }

--- a/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
@@ -97,20 +97,6 @@ public class CrateSpawner : MonoBehaviour
     void SpawnCrate(in Transform point, in SpawnRequirements requirement) 
         => requirement.instances[point] = CrateObject.Instantiate(cratePrefab, point, requirement.tag, requirement.damageBehaviour, requirement.crateScore);
 
-    // Randomise spawnable transforms (Fisher-Yates shuffle I found on stack overflow)
-    // Partition list from 0 to pointer to end -> Select random element -> swap with pointer element -> decrement pointer
-    static void ShuffleList<T>(List<T> list)
-    {
-        var rnd = new System.Random();
-        int n = list.Count;
-        while (n > 1)
-        {
-            n--;
-            int k = rnd.Next(0, n + 1);
-            (list[n], list[k]) = (list[k], list[n]);
-        }
-    }
-
     // Draws the spawner locations and what colour they are for. Size is also based on the score 
     private void OnDrawGizmosSelected()
     {


### PR DESCRIPTION
### Summary

Quotas can have their requirements randomised by the `CollectionScheduleObjectrandomiseRequiredTag` bool. This only randomises just the crate tag, nothing more, and it also preserves the other variables in the collections (as in everything else will be in the order you put them in aside from the tags, which are randomised). Randomisation is based on the values in the list.