### PR TITLE
Fix spawner breaking if spawn count is larger than possible spawn points

### DIFF
--- a/Project/Assets/_Data/Scripts/Crates/CrateExtensions.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateExtensions.cs
@@ -17,6 +17,7 @@ public static class CrateExtensions
         [Tooltip("This must be the game object whose child transforms are used as spawn points.")]
         public Transform parentTransform;
         public CrateTag tag;
+        [Min(0)]
         public int spawnCount;
         public int crateScore;
         public DamageBehaviour damageBehaviour;

--- a/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using static CrateExtensions;
 
@@ -86,7 +85,7 @@ public class CrateSpawner : MonoBehaviour
 
             // Spawn more crates until we've reached the max spawn count or spawned at all valid points
             int j = 0,
-                k = Mathf.Min(req.spawnCount, validPoints.Count);
+                k = Mathf.Clamp(req.spawnCount,0 , validPoints.Count);
             for (int i = req.Spawned; i < k;  i++)
             {
                 SpawnCrate(validPoints[j], req);

--- a/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
+++ b/Project/Assets/_Data/Scripts/Crates/CrateSpawner.cs
@@ -84,9 +84,10 @@ public class CrateSpawner : MonoBehaviour
             List<Transform> validPoints = allPoints.FindAll(item => (Object)req.instances[item] == null);
             ShuffleList(validPoints);
 
-            // Spawn more crates until we've reached the max spawn count
-            int j = 0;
-            for (int i = req.Spawned; i < req.spawnCount;  i++)
+            // Spawn more crates until we've reached the max spawn count or spawned at all valid points
+            int j = 0,
+                k = Mathf.Min(req.spawnCount, validPoints.Count);
+            for (int i = req.Spawned; i < k;  i++)
             {
                 SpawnCrate(validPoints[j], req);
                 j++;


### PR DESCRIPTION
Ideally the spawn count shouldn't be set to a number which can cause this to break, but a preventative measure for this being the case is now here to prevent the spawner from breaking.