### PR TITLE
Allow collector to accept non-quota crates at a reduced rate

### DIFF
--- a/Project/Assets/Project Data/Prefabs/Scriptable Objects/Collection/CollectionScheduleObject.asset
+++ b/Project/Assets/Project Data/Prefabs/Scriptable Objects/Collection/CollectionScheduleObject.asset
@@ -13,16 +13,17 @@ MonoBehaviour:
   m_Name: CollectionScheduleObject
   m_EditorClassIdentifier: 
   collectionSchedule:
+  - requiredTag: 0
+    requiredScore: 200
+    timeLimit: 100
   - requiredTag: 2
     requiredScore: 200
     timeLimit: 100
   - requiredTag: 1
     requiredScore: 200
     timeLimit: 100
-  - requiredTag: 0
-    requiredScore: 200
-    timeLimit: 100
   randomiseRequiredTag: 1
   quotaBonusMultiplier: 2
+  penaltyScoreMultiplier: 0.3
   totalTime: 300
   actingScheduler: {fileID: 0}

--- a/Project/Assets/Project Data/Prefabs/Scriptable Objects/Collection/CollectionScheduleObject.asset
+++ b/Project/Assets/Project Data/Prefabs/Scriptable Objects/Collection/CollectionScheduleObject.asset
@@ -13,10 +13,10 @@ MonoBehaviour:
   m_Name: CollectionScheduleObject
   m_EditorClassIdentifier: 
   collectionSchedule:
-  - requiredTag: 0
+  - requiredTag: 2
     requiredScore: 200
     timeLimit: 100
-  - requiredTag: 2
+  - requiredTag: 0
     requiredScore: 200
     timeLimit: 100
   - requiredTag: 1
@@ -24,6 +24,6 @@ MonoBehaviour:
     timeLimit: 100
   randomiseRequiredTag: 1
   quotaBonusMultiplier: 2
-  penaltyScoreMultiplier: 0.3
+  penaltyScoreMultiplier: -29.68
   totalTime: 300
   actingScheduler: {fileID: 0}

--- a/Project/Assets/Project Data/Scripts/Collection/CollectionScheduleObject.cs
+++ b/Project/Assets/Project Data/Scripts/Collection/CollectionScheduleObject.cs
@@ -18,9 +18,13 @@ public class CollectionScheduleObject : ScriptableObject
     [SerializeField, Min(1f)]
     float quotaBonusMultiplier = 1f;
 
+    [SerializeField]
+    float penaltyScoreMultiplier = 0.8f;
 
+    // These should just be the property with the field:SerializeFieldAttribute set
     [Tooltip("Score multiplier if the quota is met.")]
     public float QuotaBonusMultiplier => quotaBonusMultiplier;
+    public float PenaltyScoreMultiplier => penaltyScoreMultiplier;
 
     // This should use some special attribute so it's not editable in the inspector
     [SerializeField]

--- a/Project/Assets/Project Data/Scripts/Collection/CollectorScheduler.cs
+++ b/Project/Assets/Project Data/Scripts/Collection/CollectorScheduler.cs
@@ -30,6 +30,7 @@ public class CollectorScheduler : MonoBehaviour
     public Queue<ScheduleQuota> Schedule { get; private set; }
     public ScheduleQuota CurrentRequirement { get; private set; }
     public float BonusQuotaMultipler { get; private set; }
+    public float PenaltyScoreMultiplier { get; private set; }
     public bool Running => isRunning;
     public float RemainingQuotaTime => Mathf.Max(CurrentRequirement.timeLimit - timer.ElapsedTime, 0f);
 
@@ -56,7 +57,7 @@ public class CollectorScheduler : MonoBehaviour
         isRunning = false;
         timer.repeat = false;
         timer.autoStart = false;
-        BonusQuotaMultipler = 1f;
+        BonusQuotaMultipler = PenaltyScoreMultiplier = 1f;
     }
 
     private void OnEnable()
@@ -97,6 +98,7 @@ public class CollectorScheduler : MonoBehaviour
             Schedule.Enqueue(req);
         }
         BonusQuotaMultipler = scheduleObject.QuotaBonusMultiplier;
+        PenaltyScoreMultiplier = scheduleObject.PenaltyScoreMultiplier;
         scheduleObject.actingScheduler = this;
     }
 
@@ -121,7 +123,7 @@ public class CollectorScheduler : MonoBehaviour
         }
     }
 
-    // Attempts to get a new requirement from the stack
+    // Attempts to get a new requirement from the queue
     bool TryGetNextInSchedule(out ScheduleQuota requirement)
     {
         requirement = new ScheduleQuota();

--- a/Project/Assets/Project Data/Scripts/Collection/CrateCollector.cs
+++ b/Project/Assets/Project Data/Scripts/Collection/CrateCollector.cs
@@ -27,14 +27,6 @@ public class CrateCollector : MonoBehaviour
     [SerializeField]
     ArrayArrangement gridArrangement;
 
-    [Space, Header("Settings")]
-
-    [SerializeField, Range(0f, 100f)]
-    float rejectionLaunchForce = 10f;
-
-    [SerializeField, Range(0f, 100f)]
-    float acceptLaunchForce = 5f;
-
     [Space, Header("Event Bindings")]
 
     [SerializeField]
@@ -121,50 +113,18 @@ public class CrateCollector : MonoBehaviour
         }
     }
 
-    private void OnTriggerExit(Collider other)
-    {
-        if (other.TryGetComponent(out ICollectable collectable))
-        {
-            // RemoveCollectable(collectable);
-        }
-    }
-
     // Will attempt to collect the given collectable
     void TryCollect(ICollectable collectable)
     {
-        // Nothing is collectable
-        if (!canCollect || collectable.CanCollect == false) return;
+        // Nothing is collectable or can be collected
+        if (!canCollect || collectable.CanCollect == false || forCollection.Contains(collectable)) return;
 
-        if (collectable.Tag == collectionRequirement.requiredTag && !forCollection.Contains(collectable))
-        {
-            forCollection.Add(collectable);
-            onItemsForCollectionChanged.Invoke(GetScoreWaitingInCollection());
-            collectable.CanDamage = collectable.CanCollect = false;
-            gridArrangement.Add(collectable.GameObject.transform);
-            // collectable.GameObject.GetComponent<Rigidbody>().AddForce(-GetLaunchForce(acceptLaunchForce), ForceMode.Impulse);
-        }
-        else if (collectable.Tag != collectionRequirement.requiredTag)
-        {
-            /* This should be the proper solution to handling the crate being dropped off incorectly
-             * for now we're just gonna destroy it and let the crate spawner bring it back to life
-            var rb = collectable.GameObject.GetComponent<Rigidbody>();
-            rb.linearVelocity = Vector3.zero;
-            rb.AddForce(GetLaunchForce(rejectionLaunchForce) + new Vector3(0f, 1f, 0f), ForceMode.Impulse);
-            */
-            Destroy(collectable.GameObject);
-        }
-
-    }
-
-    // Remove collectable from the list
-    void RemoveCollectable(ICollectable collectable)
-    {
-        if (canCollect && forCollection.Contains(collectable))
-        {
-            forCollection.Remove(collectable);
-            collectable.CanDamage = true;
-            onItemsForCollectionChanged.Invoke(GetScoreWaitingInCollection());
-        }
+        // Apply penalty multiplier if the collectable doesn't match the quota
+        collectable.Score = (collectable.Tag != collectionRequirement.requiredTag) ? (int)(collectable.Score * scheduler.PenaltyScoreMultiplier) : collectable.Score;
+        collectable.CanDamage = collectable.CanCollect = false;
+        forCollection.Add(collectable);
+        gridArrangement.Add(collectable.GameObject.transform);
+        onItemsForCollectionChanged.Invoke(GetScoreWaitingInCollection());
     }
 
     // Starts the collector for collecting


### PR DESCRIPTION
What LLoyd said we should do:
- Crates which aren't required for the quota can be collected but the score is reduced.
- The reduction is based on a value set in the CollectionScheduleObjec (found at `Assets/Project Data/Prefabs/Scriptable Objects/Collection/CollectionScheduleObject.asset`):
<img width="536" height="485" alt="image" src="https://github.com/user-attachments/assets/2ab56b02-9f23-4bce-b613-01cd12c4637c" />
