### PR TITLE
Make crates briefly immune to damage when dropped

### DIFF
--- a/Project/Assets/Project Data/Prefabs/Crates/InteractableCrate.prefab
+++ b/Project/Assets/Project Data/Prefabs/Crates/InteractableCrate.prefab
@@ -239,6 +239,7 @@ MonoBehaviour:
   tempNewCrateMeshEdges: {fileID: 1522030544662680082}
   tempNewCrateMeshSupports: {fileID: 7696058888468624302}
   dropLaunchForce: 5
+  damageImmunityTime: 0.2
   onDestroyed:
     m_PersistentCalls:
       m_Calls: []

--- a/Project/Assets/Project Data/Scenes/Levels/Current Level.unity
+++ b/Project/Assets/Project Data/Scenes/Levels/Current Level.unity
@@ -5653,7 +5653,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3278701883763776178, guid: 8dc9ed0b39b496941a65dfb493fa3664, type: 3}
       propertyPath: debugPlayerCount
-      value: 4
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3278701883763776178, guid: 8dc9ed0b39b496941a65dfb493fa3664, type: 3}
       propertyPath: singleController

--- a/Project/Assets/Project Data/Scripts/Crates/CrateObject.cs
+++ b/Project/Assets/Project Data/Scripts/Crates/CrateObject.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
@@ -29,6 +31,9 @@ public class CrateObject : MonoBehaviour, ICollectable
     [SerializeField, Range(0f, 100f)]
     float dropLaunchForce = 5f;
 
+    [SerializeField, Min(0f), Tooltip("'How many seconds after dropping does the crate have damage immunity?'")]
+    float damageImmunityTime = 0.2f;
+
     [SerializeField]
     UnityEvent onDestroyed;
 	public static UnityEvent onAnyDestroyed = new UnityEvent();
@@ -40,7 +45,8 @@ public class CrateObject : MonoBehaviour, ICollectable
     TextMeshPro[] textObjects;
     Material material;
     Rigidbody body;
-
+    WaitForSeconds waitDamageImmuneTimer;
+    bool deferringImmunity;
 
     // As in the minimum score the crate can have
     float MaximumScoreReduction => maxScore * (1 - DamageBehaviour.maximumScoreLossPercentage) - DamageBehaviour.maximumScoreLossValue;
@@ -71,6 +77,8 @@ public class CrateObject : MonoBehaviour, ICollectable
         material = GetComponent<Renderer>().material;
         textObjects = GetComponentsInChildren<TextMeshPro>();
         promptSource = GetComponentInChildren<ContextualPromptSource>();
+        waitDamageImmuneTimer = new WaitForSeconds(damageImmunityTime);
+        deferringImmunity = false;
 
         startingPromptText = "<sprite name=\"Xbox_Y\">";
 
@@ -176,7 +184,8 @@ public class CrateObject : MonoBehaviour, ICollectable
     void OnDropped()
     {
         UpdatePromptTextToGrab();
-        CanCollect = CanDamage = true;
+        CanCollect = true;
+        StartCoroutine(DeferSetCanDamage(() => CanCollect == true && score > 0));       // CanDamage == true after a delay and the condition passes
         body.isKinematic = false;
         // -transform.right is apparently the forward direction of the crate relative to the forklift's forward direction
         body.AddForce(-transform.right * dropLaunchForce, ForceMode.Impulse);
@@ -226,6 +235,20 @@ public class CrateObject : MonoBehaviour, ICollectable
 				}
 			}
         }
+    }
+
+    // Delay for assigning CanDamage, provided the condition passes -> basic 'if' check: () => (var == true), or any function that returns a bool
+    // Condition is important to prevent overriding can damage at the wrong time (e.g. when the crate is destroyed or gets added to collection)
+    // Can definitely just hard-code the condition but I expect this to change between contexts so it's being done like this (sorry)
+    public IEnumerator DeferSetCanDamage(Func<bool> condition)
+    {
+        // Exit if this is already running
+        if (deferringImmunity) yield break;
+
+        deferringImmunity = true;
+        yield return waitDamageImmuneTimer;
+        if (condition.Invoke()) CanDamage = true;
+        deferringImmunity = false;
     }
 
     // Returns how much score would be lost based on the relative velocity of a collision


### PR DESCRIPTION
### Summary

Change to prevent instantly damaging crates whenever you drop them by adding a delay, to resolve Alex-Silvester/CGD-Project#253.

Done with a coroutine. The function requires a condition which is checked before allowing the crate to take damage as the delay may cause the crate to be in another context which cannot take any damage.

For example, if the crate is dropped then immediately grabbed it should not take damage, but without the condition the crate would start taking damage after a delay. Since crates do not have a state machine, the condition needs to be manually checked, so the function will take in this condition. Fortunately, you only need to pass what is essentially an 'if' statement, in the form of a function.

Though it is possible to hard code the condition as a part of the coroutine, this is done in the way it is (using Func\<bool>) for the sake of flexibility.

The duration of the immunity can be changed on the interactable crate prefab:
<img width="542" height="603" alt="image" src="https://github.com/user-attachments/assets/93de6ef3-4b21-4abd-b211-1bfd8d51c178" />


How you should call this function:
```C#
bool test = false;
// Only set CanDamage while test == true
// somewhere else in the script can adjust the value test
// Create a (lambda) function to check the value of test and pass this into the function
// Sometimes this is called a 'predicate'
StartCoroutine(DeferSetCanDamage(() => test == true))
```